### PR TITLE
Incorporating Review Feedback from Zhuoyao Lin

### DIFF
--- a/draft-ietf-rats-network-device-subscription.md
+++ b/draft-ietf-rats-network-device-subscription.md
@@ -69,7 +69,7 @@ informative:
 This document defines how to subscribe to YANG Event Streams for Remote Attestation Procedures (RATS).
 In RATS, the Conceptional Messages defined can potentially be subscribed to.
 Specifically, the YANG module defined in this document augments the YANG module for TPM-based Challenge-Response based Remote Attestation (CHARRA) to allow for subscription to the Conceptual Message type Evidence.
-Additionally, this memo provides the methods and means to define additional Event Streams for other Conceptual Messages than Evidence as illustrated in the RATS Architecture, e.g., Attestation Results, Reference Values, or Endorsements.
+Additionally, this document provides the methods and means to define additional Event Streams for other Conceptual Messages than Evidence as illustrated in the RATS Architecture, e.g., Attestation Results, Reference Values, or Endorsements.
 The module defined requires at least one TPM 1.2, TPM 2.0, or equivalent hardware implementation providing the same protected capabilities as TPMs to be available in the Attester the YANG server is running on.
 
 --- middle
@@ -77,7 +77,8 @@ The module defined requires at least one TPM 1.2, TPM 2.0, or equivalent hardwar
 # Introduction
 
 {{-rats-riv}} and {{-rats-yang-tpm-charra}} define the operational prerequisites and a YANG Model for the acquisition of Evidence and other Conceptional Messages from a network device containing at least one TPM 1.2 or TPM 2.0 or equivalent hardware implementations that include the protected capabilities as provided by TPMs.
-However, there are limitations inherent in the challenge-response based conceptual interaction model (CHARRA {{-rats-models}}) upon which these documents are based. One of these limitation is that it is up to a Verifier to request signed Evidence as provided by {{-rats-yang-tpm-charra}}, from a separate Attester which contains a TPM. The result is that the interval between the occurrence of a security-relevant change event, and the event's visibility within the interested RATS entity, such as a Verifier or a Relying Party, can be unacceptably long. It is common to convey Conceptual Messages ad-hoc or periodically via requests. As new technologies emerge, some of these solutions require Conceptual Messages to be conveyed from one RATS entity to another without the need of continuous polling. Subscription to YANG Notifications {{RFC8639}} provides a set of standardized tools to facilitate these emerging requirements. This memo specifies a YANG augment to subscribe to YANG modeled remote attestation Evidence as defined in {{-rats-yang-tpm-charra}}. Additionally, this memo provides the means to define further Event Streams to convey Conceptional Messages other than Evidence, such as Attestation Results, Endorsements, or Event Logs.
+However, there are limitations inherent in the challenge-response based conceptual interaction model (CHARRA {{-rats-models}}) upon which these documents are based. One of these limitation is that it is up to a Verifier to request signed Evidence as provided by {{-rats-yang-tpm-charra}}, from a separate Attester which contains a TPM. The result is that the interval between the occurrence of a security-relevant change event, and the event's visibility within the interested RATS entity, such as a Verifier or a Relying Party, can be unacceptably long. It is common to convey Conceptual Messages ad-hoc or periodically via requests. As new technologies emerge, some of these solutions require Conceptual Messages to be conveyed from one RATS entity to another without the need of continuous polling. Subscription to YANG Notifications {{RFC8639}} provides a set of standardized tools to facilitate these emerging requirements. This document specifies the Remote Attestation Event Stream with defining each procedure as a YANG event notification type, and augments the YANG module in RFC8639 to support the subscription to YANG modeled remote attestation Evidence as defined in {{-rats-yang-tpm-charra}}. Additionally, this document provides the means to define further Event Streams to convey Conceptional Messages other than Evidence, such as Attestation Results, Endorsements, or Event Logs.
+
 
 In essence, the limitation of poll-based interactions results in two adverse effects:
 
@@ -89,15 +90,15 @@ This specification addresses the first adverse effect by enabling a consumer of 
 
 The second adverse effect results from the use of nonces in the challenge-response interaction model {{-rats-models}} realized in {{-rats-yang-tpm-charra}}. In {{-rats-yang-tpm-charra}}, an Attester must wait for a new nonce from a Verifier before it generates a new TPM Quote. To address delays resulting from such a wait, this specification enables freshness to be asserted asynchronously via the streaming attestation interaction model {{-rats-models}}. To convey a RATS Conceptual Message, an initial nonce is provided during the subscription to an Event Stream.
 
-There are several options to refresh a nonce provided by the initial subscription or its freshness characteristics. All of these methods are out-of-band of an established subscription to YANG Notifications. Two complementary methods are taken into account by this memo:
+There are several options to refresh a nonce provided by the initial subscription or its freshness characteristics. All of these methods are out-of-band of an established subscription to YANG Notifications. Two complementary methods are taken into account by this document:
 
 1. a central provider supplies new fresh nonces, e.g. via a Handle Provider that distributes Epoch IDs to all entities in a domain as described in {{-rats-arch}} and as facilitated by the Uni-Directional Remote Attestation described in {{-rats-models}} or
 
 2. the freshness characteristics of a received nonce are updated by -- potentially periodic or ad-hoc -- out-of-band TPM Quote requests as facilitated by {{-rats-yang-tpm-charra}}.
 
-Both approaches to update the freshness characteristics of the Conceptual Messages conveyed via subscription to YANG Notification that are taken into account by this memo assume that clock drift between involved entities can occur. In consequence, in some usage scenarios the timing considerations for freshness {{-rats-arch}} might have to be updated in some regular interval. Analogously, there are can be additional methods that are not describe by but nevertheless supported by this memo.
+Both approaches to update the freshness characteristics of the Conceptual Messages conveyed via subscription to YANG Notification that are taken into account by this document assume that clock drift between involved entities can occur. In consequence, in some usage scenarios the timing considerations for freshness {{-rats-arch}} might have to be updated in some regular interval. Analogously, there are can be additional methods that are not describe by but nevertheless supported by this document.
 
-This memo enables to remove the two adverse effects described by using the YANG augment specified. The YANG augment supports, for example, a RATS Verifier to maintain a continuous appraisal procedure of verifiably fresh Attester Evidence without relying on continuous polling.
+This document enables to remove the two adverse effects described by using the YANG augment specified. The YANG augment supports, for example, a RATS Verifier to maintain a continuous appraisal procedure of verifiably fresh Attester Evidence without relying on continuous polling.
 
 # Terminology
 
@@ -321,7 +322,7 @@ Almost all YANG objects below are defined via reference from {{-rats-yang-tpm-ch
 This YANG module imports modules from {{-rats-yang-tpm-charra}} and {{RFC8639}}.  It is also work-in-progress.
 
 ~~~~ YANG
-<CODE BEGINS> ietf-rats-attestation-stream@2024-07-06.yang
+<CODE BEGINS> ietf-tpm-remote-attestation-stream@2025-01-06.yang
 {::include ietf-tpm-remote-attestation-stream@2020-12-15.yang}
 <CODE ENDS>
 ~~~~


### PR DESCRIPTION
fixes #11

* adopted the suggested change for Section 1
* adapted suggested change for Section 2 for homogeneous module naming, going with `ietf-tpm-remote-attestation-stream`
* relabeled memo to document (not part of review feedback)