### PR TITLE
addressing Roman's Feedback

### DIFF
--- a/draft-ietf-rats-network-device-subscription.md
+++ b/draft-ietf-rats-network-device-subscription.md
@@ -453,8 +453,8 @@ Almost all YANG objects below are defined via reference from {{-charra}}. Howeve
 This YANG module imports modules from {{-charra}} and {{RFC8639}}.
 
 ~~~~ YANG
-<CODE BEGINS> ietf-tpm-remote-attestation-stream@2026-04-10.yang
-{::include ietf-tpm-remote-attestation-stream@2026-04-10.yang}
+<CODE BEGINS> ietf-tpm-remote-attestation-stream@2026-06-16.yang
+{::include ietf-tpm-remote-attestation-stream@2026-06-16.yang}
 <CODE ENDS>
 ~~~~
 

--- a/ietf-tpm-remote-attestation-stream@2026-06-16.yang
+++ b/ietf-tpm-remote-attestation-stream@2026-06-16.yang
@@ -47,9 +47,9 @@ module ietf-tpm-remote-attestation-stream {
      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC
      itself for full legal notices.";
   
-  revision 2024-07-06 {
+  revision 2026-06-16 {
     description
-      "Initial version.";    
+      "Final Version";    
     reference 
       "draft-ietf-rats-network-device-subscription";
   }
@@ -222,8 +222,8 @@ module ietf-tpm-remote-attestation-stream {
     uses tpm:tpm20-attestation {
       description  
         "Provides the attestation info.  Also ensures PCRs can be
-        XPATH filtered by refining the unsigned data so that it
-        appears.";
+        XPATH (see Section 6.4. of RFC6010) filtered by refining
+        the unsigned data so that it appears,";
       refine unsigned-pcr-values {
         min-elements 1;
       }


### PR DESCRIPTION
Addressing COMMENT from Roman.

Archived-At: https://mailarchive.ietf.org/arch/msg/rats/9BWgcdPCWCRmtg59AQ5GOBUIyxY

With the exception of:

> Is there a reference for “TCG structured data”?

There is, but it is in the main document ([TPM2.0]), but not in the YANG module specification itself. We think that is good enough. The XPATH reference made sense as that is a Section in an RFC. Hauling a whole TCG reference into a description messes with the readability (I tested a few option).

We are open for suggestion, though!